### PR TITLE
feat/fix: enhance and fix filters for proposals

### DIFF
--- a/server/web/partials/proposalFilters.handlebars
+++ b/server/web/partials/proposalFilters.handlebars
@@ -105,6 +105,11 @@
   </div>
       <br>
     <div class="row ml-2 mr-2">
+      <div class="col-md">
+        Upload Date
+      </div>
+    </div>
+    <div class="row ml-2 mr-2">
         <div class="col-md-2">
             <select class="selectpicker" id="uploadedAt-date" data-style="btn-white">
                 <option value="range" role="button">Date Range</option>
@@ -121,6 +126,11 @@
                 </div>
             </div>
         </div>
+    </div>
+    <div class="row ml-2 mr-2">
+      <div class="col-md">
+        Review Date
+      </div>
     </div>
     <div class="row ml-2 mr-2">
         <div class="col-md-2">

--- a/server/web/partials/proposalFilters.handlebars
+++ b/server/web/partials/proposalFilters.handlebars
@@ -80,6 +80,7 @@
         id="feasibilityStatus"
         data-live-search="true"
         data-style="btn-white"
+        data-width="65%"
       >
         <option value="All">Filter By Feasibility Status (All)</option>
         <option value="Pending">Pending</option>
@@ -93,6 +94,7 @@
         id="reviewStatus"
         data-live-search="true"
         data-style="btn-white"
+        data-width="65%"
       >
         <option value="All">Filter By Final Review Status (All)</option>
         <option value="Approve">Approve</option>

--- a/server/web/partials/proposalFilters.handlebars
+++ b/server/web/partials/proposalFilters.handlebars
@@ -104,7 +104,7 @@
       <br>
     <div class="row ml-2 mr-2">
         <div class="col-md-2">
-            <select class="selectpicker" id="date" data-style="btn-white">
+            <select class="selectpicker" id="uploadedAt-date" data-style="btn-white">
                 <option value="range" role="button">Date Range</option>
                 <option value="exact">Exact Date</option>
             </select>
@@ -112,13 +112,31 @@
         <div class="col-md-10">
             <div class="row"> 
                 <div class="col">
-                    <input class="form-control bg-white" type="date" id="startDate" onchange="pickDate()" display="none">
+                    <input class="form-control bg-white" type="date" id="uploadedAt-startDate" onchange="pickDate('uploadedAt')" display="none">
                 </div>
                 <div class="col">
-                    <input class="form-control bg-white" type="date" id="endDate" onchange="pickDate()" display="none">                
+                    <input class="form-control bg-white" type="date" id="uploadedAt-endDate" onchange="pickDate('uploadedAt')" display="none">
                 </div>
             </div>
-        </div>   
+        </div>
+    </div>
+    <div class="row ml-2 mr-2">
+        <div class="col-md-2">
+            <select class="selectpicker" id="reviewDate-date" data-style="btn-white">
+                <option value="range" role="button">Date Range</option>
+                <option value="exact">Exact Date</option>
+            </select>
+        </div>
+        <div class="col-md-10">
+            <div class="row">
+                <div class="col">
+                    <input class="form-control bg-white" type="date" id="reviewDate-startDate" onchange="pickDate('reviewDate')" display="none">
+                </div>
+                <div class="col">
+                    <input class="form-control bg-white" type="date" id="reviewDate-endDate" onchange="pickDate('reviewDate')" display="none">
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 {{#if notDatatableView}}

--- a/server/web/partials/proposalFilters.handlebars
+++ b/server/web/partials/proposalFilters.handlebars
@@ -81,27 +81,40 @@
         data-live-search="true"
         data-style="btn-white"
       >
-        <option value="All">Filter By Status (All)</option>
+        <option value="All">Filter By Feasibility Status (All)</option>
         <option value="Pending">Pending</option>
         <option value="Feasibility Checked">Feasibility Checked</option>
         <option value="Revise Requested">Revise Requested</option>
+      </select>
+    </div>
+    <div class="col">
+      <select
+        class="selectpicker"
+        id="finalReviewStatus"
+        data-live-search="true"
+        data-style="btn-white"
+      >
+        <option value="All">Filter By Final Review Status (All)</option>
+        <option value="Approve">Approve</option>
+        <option value="Revise">Revise</option>
+        <option value="Reject">Reject</option>
       </select>
     </div>
   </div>
       <br>
     <div class="row ml-2 mr-2">
         <div class="col-md-2">
-            <select class="selectpicker" id="date" data-style="btn-white">        
+            <select class="selectpicker" id="date" data-style="btn-white">
                 <option value="range" role="button">Date Range</option>
-                <option value="exact">Exact Date</option>                      
+                <option value="exact">Exact Date</option>
             </select>
         </div>
         <div class="col-md-10">
             <div class="row"> 
-                <div class="col">                          
+                <div class="col">
                     <input class="form-control bg-white" type="date" id="startDate" onchange="pickDate()" display="none">
                 </div>
-                <div class="col">                          
+                <div class="col">
                     <input class="form-control bg-white" type="date" id="endDate" onchange="pickDate()" display="none">                
                 </div>
             </div>

--- a/server/web/partials/proposalFilters.handlebars
+++ b/server/web/partials/proposalFilters.handlebars
@@ -90,7 +90,7 @@
     <div class="col">
       <select
         class="selectpicker"
-        id="finalReviewStatus"
+        id="reviewStatus"
         data-live-search="true"
         data-style="btn-white"
       >

--- a/server/web/public/scripts/proposals/proposalsListFilters.js
+++ b/server/web/public/scripts/proposals/proposalsListFilters.js
@@ -25,7 +25,7 @@ function UpdateFiltersOnUI(url) {
           $(`#${prop}-endDate`).hide();
         }
       } else {
-        $("#" + prop + " option[value='" + val + "']").attr(
+        $("#" + prop + " option[value='" + val.replace("%20", " ") + "']").attr(
           "selected",
           "selected"
         );

--- a/server/web/public/scripts/proposals/proposalsListFilters.js
+++ b/server/web/public/scripts/proposals/proposalsListFilters.js
@@ -102,54 +102,49 @@ function goToPage(pageNo) {
   window.location = attachKeyValuesToURL("page", pageNo, url);
 }
 
-$("#date").on("change", function () {
+$("select[id$=date]").on("change", function () {
 
   const value = $(this).find("option:selected").attr("value");
   const url = window.location.href;
   if (value === "exact") {
-    $("#startDate").show();
-    $("#endDate").hide();
-    if ($("#startDate").val()) {
+    $(`#${dateAttribute}-startDate`).show();
+    $(`#${dateAttribute}-endDate`).hide();
+    if ($(`#${dateAttribute}-startDate`).val()) {
       window.location = attachKeyValuesToURL(
-        "uploadedAt",
-        $("#startDate").val(),
+        dateAttribute,
+        $(`#${dateAttribute}-startDate`).val(),
         url
       );
     }
   } else if (value === "range") {
-    $("#startDate").show();
-    $("#endDate").show();
-    if ($("#startDate").val() && $("#endDate").val()) {
+    $(`#${dateAttribute}-startDate`).show();
+    $(`#${dateAttribute}-endDate`).show();
+    if ($(`#${dateAttribute}-startDate`).val() && $(`#${dateAttribute}-endDate`).val()) {
       window.location = attachKeyValuesToURL(
-        "uploadedAt",
-        $("#startDate").val() + ":" + $("#endDate").val(),
+        dateAttribute,
+        $(`#${dateAttribute}-startDate`).val() + ":" + $(`#${dateAttribute}-endDate`).val(),
         url
       );
     }
   }
 });
 
-function pickDate() {
-
-  const filterType = $("#date").val();
-  const startDate = $("#startDate").val();
-  const endDate = $("#endDate").val();
+function pickDate(dateAttribute) {
+  const filterType = $(`#${dateAttribute}-date`).val();
+  const startDate = $(`#${dateAttribute}-startDate`).val();
+  const endDate = $(`#${dateAttribute}-endDate`).val();
   const url = window.location.href;
   if (filterType === "range" && startDate && endDate) {
-    window.location = attachKeyValuesToURL(
-      "uploadedAt",
-      startDate + ":" + endDate,
-      url
-    );
+    window.location = attachKeyValuesToURL(dateAttribute, startDate + ":" + endDate, url);
   } else if (filterType === "exact" && startDate) {
-    window.location = attachKeyValuesToURL("uploadedAt", startDate, url);
+    window.location = attachKeyValuesToURL(dateAttribute, startDate, url);
   }
   //case for resetting date filters
   else if (
     (filterType === "exact" && !startDate) ||
     (filterType === "range" && !startDate && !endDate)
   ) {
-    window.location = attachKeyValuesToURL("uploadedAt", "All", url);
+    window.location = attachKeyValuesToURL(dateAttribute, "All", url);
   }
 }
 

--- a/server/web/public/scripts/proposals/proposalsListFilters.js
+++ b/server/web/public/scripts/proposals/proposalsListFilters.js
@@ -88,7 +88,7 @@ function attachKeyValuesToURL(key, value, url) {
 function linkFilters() {
 
   $("#filters .selectpicker").each(function () {
-    if ($(this).attr("id") !== "date") {
+    if (!dateQueries.has($(this).attr("id").replace("-date", ""))) {
       $(this).on("change", function () {
         let url = window.location.href;
         const property = $(this).attr("id");

--- a/server/web/public/scripts/proposals/proposalsListFilters.js
+++ b/server/web/public/scripts/proposals/proposalsListFilters.js
@@ -1,11 +1,12 @@
 "use strict";
 
 //Update filters selected option on UI using query params in the URL
+const dateQueries = new Set(["uploadedAt", "reviewDate"]);
+
 function UpdateFiltersOnUI(url) {
 
   if (url.includes("?")) {
     let queries = url.split("?")[1].split("&");
-    const dateQueries = new Set(["uploadedAt", "reviewDate"]);
 
     for (let query of queries) {
       const prop = query.split("=")[0];

--- a/server/web/public/scripts/proposals/proposalsListFilters.js
+++ b/server/web/public/scripts/proposals/proposalsListFilters.js
@@ -5,21 +5,23 @@ function UpdateFiltersOnUI(url) {
 
   if (url.includes("?")) {
     let queries = url.split("?")[1].split("&");
+    const dateQueries = new Set(["uploadedAt", "reviewDate"]);
+
     for (let query of queries) {
       const prop = query.split("=")[0];
       const val = query.split("=")[1];
-      if (prop === "uploadedAt") {
+      if (dateQueries.has(prop)) {
         //special case for date filters, (handling both range and exact)
         if (val.includes(":")) {
           //range date filter is active
-          $("#date option[value='range']").attr("selected", "selected");
-          $("#startDate").val(val.split(":")[0]);
-          $("#endDate").val(val.split(":")[1]);
+          $(`#${prop}-date option[value='range']`).attr("selected", "selected");
+          $(`#${prop}-startDate`).val(val.split(":")[0]);
+          $(`#${prop}-endDate`).val(val.split(":")[1]);
         } else {
           //exact match date is active
-          $("#date option[value='exact']").attr("selected", "selected");
-          $("#startDate").val(val);
-          $("#endDate").hide();
+          $(`#${prop}-date option[value='exact']`).attr("selected", "selected");
+          $(`#${prop}-startDate`).val(val);
+          $(`#${prop}-endDate`).hide();
         }
       } else {
         $("#" + prop + " option[value='" + val + "']").attr(
@@ -105,6 +107,7 @@ function goToPage(pageNo) {
 $("select[id$=date]").on("change", function () {
 
   const value = $(this).find("option:selected").attr("value");
+  const dateAttribute = $(this).attr("id").split("-")[0];
   const url = window.location.href;
   if (value === "exact") {
     $(`#${dateAttribute}-startDate`).show();

--- a/server/web/routes/proposals.js
+++ b/server/web/routes/proposals.js
@@ -260,8 +260,6 @@ const register = function (server, options) {
         reviewers = await User.find({ $or:[{ roles: { reviewer: true } }, { roles: { chair: true } } ]});
       }
 
-      console.log(request.query);
-
       const result = await Proposal.pagedLookup(
         request.query,
         page,

--- a/server/web/routes/proposals.js
+++ b/server/web/routes/proposals.js
@@ -183,11 +183,40 @@ const register = function (server, options) {
           end = new Date(date.setDate(date.getDate() + 1)).toISOString();
         }
 
-        request.query["$and"] = [
+        request.query["$and"] ?
+          request.query["$and"].concat([
+            { createdAt: { $gte: new Date(start) } },
+            { createdAt: { $lt: new Date(end) } },
+          ]) :
+          request.query["$and"] = [
           { createdAt: { $gte: new Date(start) } },
           { createdAt: { $lt: new Date(end) } },
         ];
         delete request.query.uploadedAt;
+      }
+
+      if ("reviewDate" in request.query) {
+        let start;
+        let end;
+        if (request.query["reviewDate"].includes(":")) {
+          start = new Date(request.query["reviewDate"].split(":")[0]).toISOString();
+          end = new Date(request.query["reviewDate"].split(":")[1]).toISOString();
+        } else {
+          const date = new Date(request.query["reviewDate"]);
+          start = date.toISOString();
+          end = new Date(date.setDate(date.getDate() + 1)).toISOString();
+        }
+
+        request.query["$and"] ?
+          request.query["$and"].concat([
+            { reviewDate: { $gte: new Date(start) } },
+            { reviewDate: { $lt: new Date(end) } },
+          ]) :
+          request.query["$and"] = [
+          { reviewDate: { $gte: new Date(start) } },
+          { reviewDate: { $lt: new Date(end) } },
+        ];
+        delete request.query.reviewDate;
       }
 
       // if there is a sort filter
@@ -230,6 +259,8 @@ const register = function (server, options) {
         //get list of all available reviewers and chair as default options for reviewers 
         reviewers = await User.find({ $or:[{ roles: { reviewer: true } }, { roles: { chair: true } } ]});
       }
+
+      console.log(request.query);
 
       const result = await Proposal.pagedLookup(
         request.query,


### PR DESCRIPTION
- Fix feasibility status filter issue. Issue is explained below:
  - When `feasibility checked` or `revise requested` is selected, the filter will update the list properly but the filter will display `all` as selected option. It will cause the `all` option non-selectable. User has to select `pending` first then select `all` to get around it.
  - Option value has a space. It will be passed as a URL parameter which does not allow space so it will be encoded as `%20`. Backend can process this `%20` encoding as space value but the frontend script will process it as normal text.
- Add review status filter
- Add review date filter